### PR TITLE
feat(security): add authentication middleware

### DIFF
--- a/api/handlers/chat.go
+++ b/api/handlers/chat.go
@@ -2,8 +2,11 @@ package handlers
 
 import (
 	"context"
+	"encoding/json"
 	"log"
 	"net/http"
+	"regexp"
+	"strings"
 	"time"
 
 	"k8s-wizard/api/models"
@@ -15,6 +18,16 @@ import (
 // ChatHandler 处理聊天请求
 type ChatHandler struct {
 	agent agent.AgentInterface
+}
+
+type threadAwareAgent interface {
+	ProcessCommandWithClarificationAndThread(
+		ctx context.Context,
+		userMsg string,
+		formData map[string]interface{},
+		confirm *bool,
+		threadID string,
+	) (result string, clarification *models.ClarificationRequest, actionPreview *models.ActionPreview, err error)
 }
 
 func NewChatHandler(a agent.AgentInterface) *ChatHandler {
@@ -30,24 +43,49 @@ func (h *ChatHandler) Handle(c *gin.Context) {
 		return
 	}
 
-    log.Printf("📨 收到聊天请求: %s, formData: %v, confirm: %v", req.Content, req.FormData, req.Confirm)
+	log.Printf(
+		"📨 收到聊天请求: content=[REDACTED len=%d], formData=%v, confirm=%v, sessionId=%s",
+		len(req.Content),
+		redactFormData(req.FormData),
+		req.Confirm,
+		req.SessionID,
+	)
 
 	// 设置超时上下文
 	ctx, cancel := context.WithTimeout(c.Request.Context(), 60*time.Second)
 	defer cancel()
 
-	// 使用新的带澄清流程的处理方法
-	result, clarification, actionPreview, err := h.agent.ProcessCommandWithClarification(
-		ctx,
-		req.Content,
-		req.FormData,
-		req.Confirm,
+	var (
+		result        string
+		clarification *models.ClarificationRequest
+		actionPreview *models.ActionPreview
+		err           error
 	)
 
+	// If the agent supports thread-aware processing, wire sessionId through.
+	// Otherwise, fall back to the existing method for compatibility.
+	if threadAgent, ok := h.agent.(threadAwareAgent); ok {
+		result, clarification, actionPreview, err = threadAgent.ProcessCommandWithClarificationAndThread(
+			ctx,
+			req.Content,
+			req.FormData,
+			req.Confirm,
+			req.SessionID,
+		)
+	} else {
+		result, clarification, actionPreview, err = h.agent.ProcessCommandWithClarification(
+			ctx,
+			req.Content,
+			req.FormData,
+			req.Confirm,
+		)
+	}
+
 	if err != nil {
-		log.Printf("❌ 处理失败: %v", err)
+		sanitizedErr := sanitizeProviderError(err)
+		log.Printf("❌ 处理失败: %s", sanitizedErr)
 		c.JSON(http.StatusInternalServerError, models.ChatResponse{
-			Error: err.Error(),
+			Error: sanitizedErr,
 			Model: h.agent.GetModelName(),
 		})
 		return
@@ -81,4 +119,88 @@ func (h *ChatHandler) Handle(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, resp)
+}
+
+var sensitiveFieldPattern = regexp.MustCompile(`(?i)(password|passwd|secret|token|api[-_]?key|authorization|credential|private[-_]?key|client[-_]?secret|access[-_]?token|refresh[-_]?token|session|cookie|prompt|content|yaml|manifest|body)`)
+var statusCodePattern = regexp.MustCompile(`\b(4\d{2}|5\d{2})\b`)
+
+func redactFormData(formData map[string]interface{}) map[string]interface{} {
+	if formData == nil {
+		return nil
+	}
+
+	redacted := make(map[string]interface{}, len(formData))
+	for k, v := range formData {
+		if sensitiveFieldPattern.MatchString(strings.TrimSpace(k)) {
+			redacted[k] = "[REDACTED]"
+			continue
+		}
+		redacted[k] = redactValue(v)
+	}
+	return redacted
+}
+
+func redactValue(v interface{}) interface{} {
+	switch t := v.(type) {
+	case map[string]interface{}:
+		return redactFormData(t)
+	case []interface{}:
+		out := make([]interface{}, len(t))
+		for i, item := range t {
+			out[i] = redactValue(item)
+		}
+		return out
+	case string:
+		trimmed := strings.TrimSpace(t)
+		if trimmed == "" {
+			return ""
+		}
+		return "[REDACTED]"
+	default:
+		return v
+	}
+}
+
+func sanitizeProviderError(err error) string {
+	if err == nil {
+		return "请求失败"
+	}
+
+	msg := strings.TrimSpace(err.Error())
+	if msg == "" {
+		return "请求失败"
+	}
+
+	if status := statusCodePattern.FindString(msg); status != "" {
+		switch status {
+		case "400":
+			return "上游服务拒绝了请求"
+		case "401", "403":
+			return "上游服务认证失败"
+		case "404":
+			return "上游服务资源不存在"
+		case "408", "504":
+			return "上游服务超时"
+		case "429":
+			return "上游服务请求过于频繁，请稍后重试"
+		default:
+			if strings.HasPrefix(status, "5") {
+				return "上游服务暂时不可用，请稍后重试"
+			}
+			return "请求处理失败"
+		}
+	}
+
+	lowerMsg := strings.ToLower(msg)
+	if strings.Contains(lowerMsg, "timeout") || strings.Contains(lowerMsg, "deadline exceeded") {
+		return "上游服务超时"
+	}
+	if strings.Contains(lowerMsg, "connection refused") || strings.Contains(lowerMsg, "no such host") {
+		return "上游服务连接失败"
+	}
+	if json.Valid([]byte(msg)) || strings.Contains(msg, "{") || strings.Contains(msg, "[") {
+		return "上游服务请求失败"
+	}
+
+	return "请求处理失败"
 }

--- a/api/handlers/chat.go
+++ b/api/handlers/chat.go
@@ -115,7 +115,7 @@ func (h *ChatHandler) Handle(c *gin.Context) {
 	// 如果都成功，标记为已执行
 	if clarification == nil && actionPreview == nil {
 		resp.Status = "executed"
-		log.Printf("✅ 处理成功: %s", result)
+		log.Printf("✅ 处理成功: result=[REDACTED len=%d]", len(result))
 	}
 
 	c.JSON(http.StatusOK, resp)

--- a/api/handlers/chat_error_test.go
+++ b/api/handlers/chat_error_test.go
@@ -1,0 +1,57 @@
+package handlers
+
+import "testing"
+
+func TestSanitizeProviderError(t *testing.T) {
+	testCases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "status 401",
+			in:   "upstream failed with 401 unauthorized",
+			want: "上游服务认证失败",
+		},
+		{
+			name: "status 500",
+			in:   "request failed: 500",
+			want: "上游服务暂时不可用，请稍后重试",
+		},
+		{
+			name: "timeout text",
+			in:   "deadline exceeded while waiting",
+			want: "上游服务超时",
+		},
+		{
+			name: "connection refused",
+			in:   "dial tcp: connection refused",
+			want: "上游服务连接失败",
+		},
+		{
+			name: "json payload",
+			in:   `{"error":"bad request","code":400}`,
+			want: "上游服务拒绝了请求",
+		},
+		{
+			name: "generic message",
+			in:   "something bad happened",
+			want: "请求处理失败",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sanitizeProviderError(testError(tc.in))
+			if got != tc.want {
+				t.Fatalf("sanitizeProviderError() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+type testError string
+
+func (e testError) Error() string {
+	return string(e)
+}

--- a/api/handlers/chat_test.go
+++ b/api/handlers/chat_test.go
@@ -1,0 +1,120 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"k8s-wizard/api/models"
+
+	"github.com/gin-gonic/gin"
+)
+
+type mockAgent struct {
+	processCalled bool
+	lastMsg       string
+	lastFormData  map[string]interface{}
+	lastConfirm   *bool
+}
+
+func (m *mockAgent) ProcessCommandWithClarification(ctx context.Context, userMsg string, formData map[string]interface{}, confirm *bool) (string, *models.ClarificationRequest, *models.ActionPreview, error) {
+	m.processCalled = true
+	m.lastMsg = userMsg
+	m.lastFormData = formData
+	m.lastConfirm = confirm
+	return "ok", nil, nil, nil
+}
+
+func (m *mockAgent) ProcessCommand(ctx context.Context, userMsg string) (string, error) {
+	return "ok", nil
+}
+
+func (m *mockAgent) GetModelName() string {
+	return "mock-model"
+}
+
+func (m *mockAgent) SetModel(modelString string) error {
+	return nil
+}
+
+type mockThreadAwareAgent struct {
+	mockAgent
+	threadCalled bool
+	lastThreadID string
+}
+
+func (m *mockThreadAwareAgent) ProcessCommandWithClarificationAndThread(ctx context.Context, userMsg string, formData map[string]interface{}, confirm *bool, threadID string) (string, *models.ClarificationRequest, *models.ActionPreview, error) {
+	m.threadCalled = true
+	m.lastMsg = userMsg
+	m.lastFormData = formData
+	m.lastConfirm = confirm
+	m.lastThreadID = threadID
+	return "ok", nil, nil, nil
+}
+
+func TestChatHandler_UsesSessionIDWhenThreadAwareAgent(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	agent := &mockThreadAwareAgent{}
+	handler := NewChatHandler(agent)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	body := `{"content":"deploy nginx","sessionId":"session-123","formData":{"name":"nginx"}}`
+	req := httptest.NewRequest(http.MethodPost, "/api/chat", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	c.Request = req
+
+	handler.Handle(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	if !agent.threadCalled {
+		t.Fatal("expected ProcessCommandWithClarificationAndThread to be called")
+	}
+	if agent.lastThreadID != "session-123" {
+		t.Fatalf("threadID = %q, want %q", agent.lastThreadID, "session-123")
+	}
+	if agent.processCalled {
+		t.Fatal("expected ProcessCommandWithClarification not to be called when thread-aware method exists")
+	}
+}
+
+func TestChatHandler_FallsBackWhenAgentNotThreadAware(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	agent := &mockAgent{}
+	handler := NewChatHandler(agent)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	confirm := true
+	payload := map[string]interface{}{
+		"content":   "deploy nginx",
+		"sessionId": "session-456",
+		"confirm":   confirm,
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/chat", strings.NewReader(string(raw)))
+	req.Header.Set("Content-Type", "application/json")
+	c.Request = req
+
+	handler.Handle(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	if !agent.processCalled {
+		t.Fatal("expected fallback ProcessCommandWithClarification to be called")
+	}
+	if agent.lastConfirm == nil || !*agent.lastConfirm {
+		t.Fatal("expected confirm to be forwarded in fallback path")
+	}
+}

--- a/api/handlers/chat_test.go
+++ b/api/handlers/chat_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -18,6 +19,7 @@ type mockAgent struct {
 	lastMsg       string
 	lastFormData  map[string]interface{}
 	lastConfirm   *bool
+	processErr    error
 }
 
 func (m *mockAgent) ProcessCommandWithClarification(ctx context.Context, userMsg string, formData map[string]interface{}, confirm *bool) (string, *models.ClarificationRequest, *models.ActionPreview, error) {
@@ -25,6 +27,9 @@ func (m *mockAgent) ProcessCommandWithClarification(ctx context.Context, userMsg
 	m.lastMsg = userMsg
 	m.lastFormData = formData
 	m.lastConfirm = confirm
+	if m.processErr != nil {
+		return "", nil, nil, m.processErr
+	}
 	return "ok", nil, nil, nil
 }
 
@@ -116,5 +121,58 @@ func TestChatHandler_FallsBackWhenAgentNotThreadAware(t *testing.T) {
 	}
 	if agent.lastConfirm == nil || !*agent.lastConfirm {
 		t.Fatal("expected confirm to be forwarded in fallback path")
+	}
+}
+
+func TestChatHandler_InvalidJSONReturnsBadRequest(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	handler := NewChatHandler(&mockAgent{})
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/chat", strings.NewReader("{invalid json"))
+	req.Header.Set("Content-Type", "application/json")
+	c.Request = req
+
+	handler.Handle(c)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+	if !strings.Contains(w.Body.String(), "无效的请求格式") {
+		t.Fatalf("unexpected response body: %s", w.Body.String())
+	}
+}
+
+func TestChatHandler_SanitizesProviderErrorInResponse(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	handler := NewChatHandler(&mockAgent{
+		processErr: errors.New("provider error: status 429: rate limit"),
+	})
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/chat", strings.NewReader(`{"content":"test"}`))
+	req.Header.Set("Content-Type", "application/json")
+	c.Request = req
+
+	handler.Handle(c)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusInternalServerError)
+	}
+
+	var resp models.ChatResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	if resp.Error != "上游服务请求过于频繁，请稍后重试" {
+		t.Fatalf("error = %q, want %q", resp.Error, "上游服务请求过于频繁，请稍后重试")
+	}
+	if resp.Model != "mock-model" {
+		t.Fatalf("model = %q, want %q", resp.Model, "mock-model")
 	}
 }

--- a/api/handlers/config.go
+++ b/api/handlers/config.go
@@ -110,13 +110,41 @@ func (h *ConfigHandler) SetModel(c *gin.Context) {
 		return
 	}
 
-	// 调用 Agent 切换模型
+	// 默认持久化模型切换结果
+	persist := true
+	if req.Persist != nil {
+		persist = *req.Persist
+	}
+
+	// 切换运行时模型（包含 client/graph 重建）
 	if err := h.agent.SetModel(req.Model); err != nil {
-		c.JSON(http.StatusBadRequest, models.SetModelResponse{
+		c.JSON(http.StatusInternalServerError, models.SetModelResponse{
 			Success: false,
-			Error:   err.Error(),
+			Error:   "模型切换失败: " + err.Error(),
 		})
 		return
+	}
+
+	if persist {
+		cfg, err := config.LoadConfig()
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, models.SetModelResponse{
+				Success: false,
+				Model:   h.agent.GetModelName(),
+				Error:   "模型已切换，但加载配置失败: " + err.Error(),
+			})
+			return
+		}
+
+		cfg.Agents.Defaults.Model.Primary = req.Model
+		if err := cfg.Save(); err != nil {
+			c.JSON(http.StatusInternalServerError, models.SetModelResponse{
+				Success: false,
+				Model:   h.agent.GetModelName(),
+				Error:   "模型已切换，但保存配置失败: " + err.Error(),
+			})
+			return
+		}
 	}
 
 	c.JSON(http.StatusOK, models.SetModelResponse{

--- a/api/middleware/auth.go
+++ b/api/middleware/auth.go
@@ -1,0 +1,213 @@
+package middleware
+
+import (
+	"bytes"
+	"crypto/subtle"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"regexp"
+	"strings"
+
+	"k8s-wizard/api/models"
+
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	contextKeyAuthRole = "auth.role"
+	roleAnonymous      = "anonymous"
+	roleUser           = "user"
+	roleAdmin          = "admin"
+)
+
+var dangerousVerbPattern = regexp.MustCompile(`(?i)\b(create|delete|scale)\b|创建|删除|扩容|缩容|伸缩`)
+
+// AuthConfig holds auth-related runtime configuration.
+type AuthConfig struct {
+	RequireAuth bool
+	UserToken   string
+	AdminToken  string
+}
+
+// NewAuthConfigFromEnv creates auth configuration from environment variables.
+//
+// Environment variables:
+// - K8S_WIZARD_ENV: set to "production"/"prod" to default auth to required.
+// - K8S_WIZARD_AUTH_REQUIRED: explicit override (true/false).
+// - K8S_WIZARD_API_TOKEN: bearer token for authenticated API access.
+// - K8S_WIZARD_ADMIN_TOKEN: admin token; defaults to API token when omitted.
+func NewAuthConfigFromEnv() AuthConfig {
+	env := strings.ToLower(strings.TrimSpace(os.Getenv("K8S_WIZARD_ENV")))
+	if env == "" {
+		env = strings.ToLower(strings.TrimSpace(os.Getenv("APP_ENV")))
+	}
+	if env == "" {
+		env = strings.ToLower(strings.TrimSpace(os.Getenv("ENV")))
+	}
+
+	requireAuth := env == "production" || env == "prod"
+	if v, ok := parseBoolEnv("K8S_WIZARD_AUTH_REQUIRED"); ok {
+		requireAuth = v
+	}
+
+	userToken := strings.TrimSpace(os.Getenv("K8S_WIZARD_API_TOKEN"))
+	adminToken := strings.TrimSpace(os.Getenv("K8S_WIZARD_ADMIN_TOKEN"))
+	if adminToken == "" {
+		adminToken = userToken
+	}
+
+	return AuthConfig{
+		RequireAuth: requireAuth,
+		UserToken:   userToken,
+		AdminToken:  adminToken,
+	}
+}
+
+func parseBoolEnv(name string) (bool, bool) {
+	v, ok := os.LookupEnv(name)
+	if !ok {
+		return false, false
+	}
+
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "1", "true", "yes", "on":
+		return true, true
+	case "0", "false", "no", "off":
+		return false, true
+	default:
+		return false, false
+	}
+}
+
+// TokenAuth validates bearer tokens and sets request role in context.
+func TokenAuth(cfg AuthConfig) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		headerToken, hasToken := bearerToken(c.GetHeader("Authorization"))
+
+		if !hasToken {
+			if cfg.RequireAuth {
+				c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "authentication required"})
+				return
+			}
+			c.Set(contextKeyAuthRole, roleAnonymous)
+			c.Next()
+			return
+		}
+
+		if tokenEquals(headerToken, cfg.AdminToken) {
+			c.Set(contextKeyAuthRole, roleAdmin)
+			c.Next()
+			return
+		}
+		if tokenEquals(headerToken, cfg.UserToken) {
+			c.Set(contextKeyAuthRole, roleUser)
+			c.Next()
+			return
+		}
+
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid authentication token"})
+	}
+}
+
+func bearerToken(header string) (string, bool) {
+	header = strings.TrimSpace(header)
+	if header == "" {
+		return "", false
+	}
+	const prefix = "bearer "
+	if len(header) < len(prefix) || strings.ToLower(header[:len(prefix)]) != prefix {
+		return "", false
+	}
+	token := strings.TrimSpace(header[len(prefix):])
+	if token == "" {
+		return "", false
+	}
+	return token, true
+}
+
+func tokenEquals(got, expected string) bool {
+	if expected == "" || got == "" {
+		return false
+	}
+	if len(got) != len(expected) {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(got), []byte(expected)) == 1
+}
+
+// RequireDangerousOperationAuth restricts dangerous chat operations to admin role.
+func RequireDangerousOperationAuth() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if !isDangerousChatRequest(c) {
+			c.Next()
+			return
+		}
+
+		role := roleAnonymous
+		if v, exists := c.Get(contextKeyAuthRole); exists {
+			if s, ok := v.(string); ok {
+				role = s
+			}
+		}
+
+		if role != roleAdmin {
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "dangerous operations require admin authorization"})
+			return
+		}
+
+		c.Next()
+	}
+}
+
+func isDangerousChatRequest(c *gin.Context) bool {
+	if c.Request.Method != http.MethodPost {
+		return false
+	}
+
+	body, err := io.ReadAll(c.Request.Body)
+	if err != nil {
+		return false
+	}
+	c.Request.Body = io.NopCloser(bytes.NewBuffer(body))
+	if len(bytes.TrimSpace(body)) == 0 {
+		return false
+	}
+
+	var req models.ChatRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return false
+	}
+
+	if dangerousVerbPattern.MatchString(req.Content) {
+		return true
+	}
+
+	for k, v := range req.FormData {
+		kl := strings.ToLower(strings.TrimSpace(k))
+		if kl != "action" && kl != "type" && kl != "operation" && kl != "method" && kl != "tool" && kl != "tool_name" {
+			continue
+		}
+		if dangerousVerbPattern.MatchString(strings.TrimSpace(toString(v))) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func toString(v interface{}) string {
+	switch t := v.(type) {
+	case string:
+		return t
+	case []byte:
+		return string(t)
+	default:
+		b, err := json.Marshal(v)
+		if err != nil {
+			return ""
+		}
+		return string(b)
+	}
+}

--- a/api/middleware/auth_cors_test.go
+++ b/api/middleware/auth_cors_test.go
@@ -1,0 +1,66 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestTokenAuth_InvalidToken(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	router := gin.New()
+	router.Use(TokenAuth(AuthConfig{RequireAuth: true, UserToken: "user-token", AdminToken: "admin-token"}))
+	router.GET("/protected", func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+	req.Header.Set("Authorization", "Bearer wrong-token")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestCORS_WildcardOriginDisablesCredentials(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	orig := os.Getenv(allowedOriginsEnv)
+	if err := os.Setenv(allowedOriginsEnv, "*"); err != nil {
+		t.Fatalf("set env: %v", err)
+	}
+	t.Cleanup(func() {
+		if orig == "" {
+			_ = os.Unsetenv(allowedOriginsEnv)
+		} else {
+			_ = os.Setenv(allowedOriginsEnv, orig)
+		}
+	})
+
+	router := gin.New()
+	router.Use(CORS())
+	router.GET("/chat", func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/chat", nil)
+	req.Header.Set("Origin", "https://any-origin.example.com")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "*" {
+		t.Fatalf("allow-origin = %q, want %q", got, "*")
+	}
+	if got := w.Header().Get("Access-Control-Allow-Credentials"); got != "" {
+		t.Fatalf("allow-credentials = %q, want empty", got)
+	}
+}

--- a/api/middleware/cors.go
+++ b/api/middleware/cors.go
@@ -1,16 +1,53 @@
 package middleware
 
 import (
+	"net/http"
+	"os"
+	"strings"
+
 	"github.com/gin-gonic/gin"
 )
 
+const allowedOriginsEnv = "K8S_WIZARD_ALLOWED_ORIGINS"
+
+var defaultAllowedOrigins = []string{
+	"http://localhost:3000",
+	"http://127.0.0.1:3000",
+	"http://localhost:5173",
+	"http://127.0.0.1:5173",
+}
+
+// CORSConfig holds runtime CORS configuration.
+type CORSConfig struct {
+	AllowAll       bool
+	AllowOrigins   map[string]struct{}
+	AllowCredsMode bool
+}
+
 // CORS 跨域中间件
 func CORS() gin.HandlerFunc {
+	cfg := newCORSConfigFromEnv()
+
 	return func(c *gin.Context) {
-		c.Writer.Header().Set("Access-Control-Allow-Origin", "*")
+		origin := strings.TrimSpace(c.GetHeader("Origin"))
+
+		if origin != "" {
+			allowed, matchedOrigin := isOriginAllowed(origin, cfg)
+			if !allowed {
+				c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "origin not allowed"})
+				return
+			}
+			c.Writer.Header().Set("Access-Control-Allow-Origin", matchedOrigin)
+		} else if cfg.AllowAll {
+			c.Writer.Header().Set("Access-Control-Allow-Origin", "*")
+		}
+
+		c.Writer.Header().Set("Vary", "Origin")
 		c.Writer.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
 		c.Writer.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
-		c.Writer.Header().Set("Access-Control-Allow-Credentials", "true")
+		if cfg.AllowCredsMode {
+			c.Writer.Header().Set("Access-Control-Allow-Credentials", "true")
+		}
 
 		if c.Request.Method == "OPTIONS" {
 			c.AbortWithStatus(204)
@@ -18,4 +55,50 @@ func CORS() gin.HandlerFunc {
 		}
 		c.Next()
 	}
+}
+
+func newCORSConfigFromEnv() CORSConfig {
+	raw := strings.TrimSpace(os.Getenv(allowedOriginsEnv))
+	origins := make(map[string]struct{})
+
+	// Safe default for local development when env var is not configured.
+	if raw == "" {
+		for _, origin := range defaultAllowedOrigins {
+			origins[origin] = struct{}{}
+		}
+		return CORSConfig{
+			AllowAll:       false,
+			AllowOrigins:   origins,
+			AllowCredsMode: true,
+		}
+	}
+
+	allowAll := false
+	for _, token := range strings.Split(raw, ",") {
+		origin := strings.TrimSpace(token)
+		if origin == "" {
+			continue
+		}
+		if origin == "*" {
+			allowAll = true
+			continue
+		}
+		origins[origin] = struct{}{}
+	}
+
+	return CORSConfig{
+		AllowAll:       allowAll,
+		AllowOrigins:   origins,
+		AllowCredsMode: !allowAll,
+	}
+}
+
+func isOriginAllowed(origin string, cfg CORSConfig) (bool, string) {
+	if _, ok := cfg.AllowOrigins[origin]; ok {
+		return true, origin
+	}
+	if cfg.AllowAll {
+		return true, "*"
+	}
+	return false, ""
 }

--- a/api/middleware/middleware_test.go
+++ b/api/middleware/middleware_test.go
@@ -1,0 +1,160 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestTokenAuth_RequireAuthWithoutToken(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	router := gin.New()
+	router.Use(TokenAuth(AuthConfig{RequireAuth: true, UserToken: "user-token", AdminToken: "admin-token"}))
+	router.GET("/protected", func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestTokenAuth_ValidUserToken(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	router := gin.New()
+	router.Use(TokenAuth(AuthConfig{RequireAuth: true, UserToken: "user-token", AdminToken: "admin-token"}))
+	router.GET("/protected", func(c *gin.Context) {
+		role, _ := c.Get(contextKeyAuthRole)
+		c.JSON(http.StatusOK, gin.H{"role": role})
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+	req.Header.Set("Authorization", "Bearer user-token")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+	if body := w.Body.String(); body != "{\"role\":\"user\"}" {
+		t.Fatalf("body = %s, want %s", body, "{\"role\":\"user\"}")
+	}
+}
+
+func TestRequireDangerousOperationAuth_ForbidsNonAdmin(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	router := gin.New()
+	router.Use(TokenAuth(AuthConfig{RequireAuth: true, UserToken: "user-token", AdminToken: "admin-token"}))
+	router.Use(RequireDangerousOperationAuth())
+	router.POST("/chat", func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/chat", strings.NewReader(`{"content":"delete deployment nginx"}`))
+	req.Header.Set("Authorization", "Bearer user-token")
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusForbidden)
+	}
+}
+
+func TestRequireDangerousOperationAuth_AllowsAdmin(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	router := gin.New()
+	router.Use(TokenAuth(AuthConfig{RequireAuth: true, UserToken: "user-token", AdminToken: "admin-token"}))
+	router.Use(RequireDangerousOperationAuth())
+	router.POST("/chat", func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/chat", strings.NewReader(`{"content":"delete deployment nginx"}`))
+	req.Header.Set("Authorization", "Bearer admin-token")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+}
+
+func TestCORS_AllowsConfiguredOriginAndHandlesPreflight(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	orig := os.Getenv(allowedOriginsEnv)
+	if err := os.Setenv(allowedOriginsEnv, "https://ui.example.com"); err != nil {
+		t.Fatalf("set env: %v", err)
+	}
+	t.Cleanup(func() {
+		if orig == "" {
+			_ = os.Unsetenv(allowedOriginsEnv)
+		} else {
+			_ = os.Setenv(allowedOriginsEnv, orig)
+		}
+	})
+
+	router := gin.New()
+	router.Use(CORS())
+	router.OPTIONS("/chat", func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodOptions, "/chat", nil)
+	req.Header.Set("Origin", "https://ui.example.com")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusNoContent)
+	}
+	if got := w.Header().Get("Access-Control-Allow-Origin"); got != "https://ui.example.com" {
+		t.Fatalf("allow-origin = %q, want %q", got, "https://ui.example.com")
+	}
+}
+
+func TestCORS_RejectsDisallowedOrigin(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	orig := os.Getenv(allowedOriginsEnv)
+	if err := os.Setenv(allowedOriginsEnv, "https://ui.example.com"); err != nil {
+		t.Fatalf("set env: %v", err)
+	}
+	t.Cleanup(func() {
+		if orig == "" {
+			_ = os.Unsetenv(allowedOriginsEnv)
+		} else {
+			_ = os.Setenv(allowedOriginsEnv, orig)
+		}
+	})
+
+	router := gin.New()
+	router.Use(CORS())
+	router.GET("/chat", func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/chat", nil)
+	req.Header.Set("Origin", "https://evil.example.com")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusForbidden)
+	}
+}

--- a/api/models/requests.go
+++ b/api/models/requests.go
@@ -5,20 +5,20 @@ type ChatRequest struct {
 	Content   string                 `json:"content" binding:"required"`
 	Namespace string                 `json:"namespace,omitempty"`
 	FormData  map[string]interface{} `json:"formData,omitempty"`  // 表单数据
-	Confirm   *bool                  `json:"confirm,omitempty"`    // 确认执行
-	SessionID string                 `json:"sessionId,omitempty"`  // 会话 ID
+	Confirm   *bool                  `json:"confirm,omitempty"`   // 确认执行
+	SessionID string                 `json:"sessionId,omitempty"` // 会话 ID
 }
 
 // ChatResponse 聊天响应
 type ChatResponse struct {
-	Result        string                 `json:"result"`
-	Message       string                 `json:"message,omitempty"`
-	Error         string                 `json:"error,omitempty"`
-	Model         string                 `json:"model,omitempty"`
-	Clarification *ClarificationRequest  `json:"clarification,omitempty"`
-	ActionPreview *ActionPreview         `json:"actionPreview,omitempty"`
-	Status        string                 `json:"status,omitempty"` // pending, confirmed, executed
-	Suggestions   []Suggestion            `json:"suggestions,omitempty"` // NEW: Add suggestions field
+	Result        string                `json:"result"`
+	Message       string                `json:"message,omitempty"`
+	Error         string                `json:"error,omitempty"`
+	Model         string                `json:"model,omitempty"`
+	Clarification *ClarificationRequest `json:"clarification,omitempty"`
+	ActionPreview *ActionPreview        `json:"actionPreview,omitempty"`
+	Status        string                `json:"status,omitempty"`      // pending, confirmed, executed
+	Suggestions   []Suggestion          `json:"suggestions,omitempty"` // NEW: Add suggestions field
 }
 
 // HealthResponse 健康检查响应
@@ -59,7 +59,8 @@ type ProviderInfo struct {
 
 // SetModelRequest 切换模型请求
 type SetModelRequest struct {
-	Model string `json:"model" binding:"required"` // 格式: provider/model-id, 例如: glm/glm-4-flash
+	Model   string `json:"model" binding:"required"` // 格式: provider/model-id, 例如: glm/glm-4-flash
+	Persist *bool  `json:"persist,omitempty"`        // 是否持久化到配置文件，默认 true
 }
 
 // SetModelResponse 切换模型响应
@@ -72,14 +73,14 @@ type SetModelResponse struct {
 
 // ClarificationField 澄清字段
 type ClarificationField struct {
-	Key         string                   `json:"key"`
-	Label       string                   `json:"label"`
-	Type        string                   `json:"type"`  // text, select, number, textarea
-	Placeholder string                   `json:"placeholder,omitempty"`
-	Default     interface{}              `json:"default,omitempty"`
-	Options     []ClarificationOption    `json:"options,omitempty"`
-	Required    bool                     `json:"required"`
-	Group       string                   `json:"group,omitempty"` // 用于分组: "basic", "advanced"
+	Key         string                `json:"key"`
+	Label       string                `json:"label"`
+	Type        string                `json:"type"` // text, select, number, textarea
+	Placeholder string                `json:"placeholder,omitempty"`
+	Default     interface{}           `json:"default,omitempty"`
+	Options     []ClarificationOption `json:"options,omitempty"`
+	Required    bool                  `json:"required"`
+	Group       string                `json:"group,omitempty"` // 用于分组: "basic", "advanced"
 }
 
 // ClarificationOption 选项
@@ -90,21 +91,20 @@ type ClarificationOption struct {
 
 // ClarificationRequest 澄清请求
 type ClarificationRequest struct {
-	Type        string              `json:"type"`  // form, options, confirm
-	Title       string              `json:"title"`
-	Description string              `json:"description,omitempty"`
+	Type        string               `json:"type"` // form, options, confirm
+	Title       string               `json:"title"`
+	Description string               `json:"description,omitempty"`
 	Fields      []ClarificationField `json:"fields"`
-	Action      string              `json:"action,omitempty"` // create, delete, scale, get
+	Action      string               `json:"action,omitempty"` // create, delete, scale, get
 }
 
 // ActionPreview 操作预览
 type ActionPreview struct {
-	Type        string                 `json:"type"`        // create, delete, scale, get
-	Resource    string                 `json:"resource"`    // deployment/nginx
+	Type        string                 `json:"type"`     // create, delete, scale, get
+	Resource    string                 `json:"resource"` // deployment/nginx
 	Namespace   string                 `json:"namespace"`
 	YAML        string                 `json:"yaml,omitempty"`
 	Params      map[string]interface{} `json:"params"`
 	DangerLevel string                 `json:"dangerLevel"` // low, medium, high
 	Summary     string                 `json:"summary"`     // 人类可读的摘要
 }
-

--- a/cmd/k8s-wizard/main.go
+++ b/cmd/k8s-wizard/main.go
@@ -39,7 +39,14 @@ func main() {
 
 	logger.Info("agent initialized", "model", ag.GetModelName())
 
-	router := setupRouter(ag)
+	authCfg := middleware.NewAuthConfigFromEnv()
+	logger.Info("auth configuration initialized",
+		"requireAuth", authCfg.RequireAuth,
+		"hasApiToken", authCfg.UserToken != "",
+		"hasAdminToken", authCfg.AdminToken != "",
+	)
+
+	router := setupRouter(ag, authCfg)
 	srv := &http.Server{
 		Addr:    getBindAddr(cfg),
 		Handler: router,
@@ -81,7 +88,7 @@ func getBindAddr(cfg *config.Config) string {
 	return ":" + port
 }
 
-func setupRouter(ag agent.AgentInterface) *gin.Engine {
+func setupRouter(ag agent.AgentInterface, authCfg middleware.AuthConfig) *gin.Engine {
 	gin.SetMode(gin.ReleaseMode)
 
 	r := gin.New()
@@ -92,9 +99,10 @@ func setupRouter(ag agent.AgentInterface) *gin.Engine {
 	r.GET("/health", handlers.HealthCheck)
 
 	api := r.Group("/api")
+	api.Use(middleware.TokenAuth(authCfg))
 	{
 		chatHandler := handlers.NewChatHandler(ag)
-		api.POST("/chat", chatHandler.Handle)
+		api.POST("/chat", middleware.RequireDangerousOperationAuth(), chatHandler.Handle)
 
 		resourcesHandler := handlers.NewResourcesHandler(ag)
 		api.GET("/resources", resourcesHandler.Handle)

--- a/cmd/k8s-wizard/main.go
+++ b/cmd/k8s-wizard/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strconv"
 	"os/signal"
 	"syscall"
 	"time"
@@ -48,8 +49,12 @@ func main() {
 
 	router := setupRouter(ag, authCfg)
 	srv := &http.Server{
-		Addr:    getBindAddr(cfg),
-		Handler: router,
+		Addr:              getBindAddr(cfg),
+		Handler:           router,
+		ReadHeaderTimeout: getServerTimeoutFromEnv("K8S_WIZARD_HTTP_READ_HEADER_TIMEOUT", 10*time.Second),
+		ReadTimeout:       getServerTimeoutFromEnv("K8S_WIZARD_HTTP_READ_TIMEOUT", 30*time.Second),
+		WriteTimeout:      getServerTimeoutFromEnv("K8S_WIZARD_HTTP_WRITE_TIMEOUT", 60*time.Second),
+		IdleTimeout:       getServerTimeoutFromEnv("K8S_WIZARD_HTTP_IDLE_TIMEOUT", 120*time.Second),
 	}
 
 	go startServer(srv)
@@ -170,4 +175,31 @@ func waitForShutdown(srv *http.Server) {
 	}
 
 	logger.Info("server exited")
+}
+
+func getServerTimeoutFromEnv(key string, fallback time.Duration) time.Duration {
+	value, ok := os.LookupEnv(key)
+	if !ok || value == "" {
+		return fallback
+	}
+
+	// Prefer standard duration values like "30s"; fallback to raw seconds for convenience.
+	if d, err := time.ParseDuration(value); err == nil {
+		if d > 0 {
+			return d
+		}
+		logger.Warn("invalid server timeout duration (must be > 0), using default", "env", key, "value", value, "default", fallback.String())
+		return fallback
+	}
+
+	if seconds, err := strconv.Atoi(value); err == nil {
+		if seconds > 0 {
+			return time.Duration(seconds) * time.Second
+		}
+		logger.Warn("invalid server timeout seconds (must be > 0), using default", "env", key, "value", value, "default", fallback.String())
+		return fallback
+	}
+
+	logger.Warn("invalid server timeout format, using default", "env", key, "value", value, "default", fallback.String())
+	return fallback
 }

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -63,9 +63,9 @@ func NewGraphAgent(k8sClient k8s.Client, llmClient llm.Client, modelName string)
 		ModelName:    modelName,
 		ToolRegistry: tools.NewRegistry(),
 		// PromptLoader, SubGraphMgr, ContextMgr will be initialized in later phases
-		PromptLoader: nil,
-		SubGraphMgr:  nil,
-		ContextMgr:   nil,
+		PromptLoader:     nil,
+		SubGraphMgr:      nil,
+		ContextMgr:       nil,
 		SuggestionEngine: suggestionEngine,
 	}
 
@@ -91,6 +91,7 @@ func (a *GraphAgent) ProcessCommandWithClarification(
 ) (result string, clarification *models.ClarificationRequest, actionPreview *models.ActionPreview, err error) {
 	a.mu.RLock()
 	modelName := a.modelName
+	graph := a.graph
 	a.mu.RUnlock()
 
 	// Build initial state
@@ -103,7 +104,7 @@ func (a *GraphAgent) ProcessCommandWithClarification(
 	_ = modelName // modelName is currently unused but kept for future use
 
 	// Execute the graph
-	finalState, execErr := a.graph.Invoke(ctx, initialState)
+	finalState, execErr := graph.Invoke(ctx, initialState)
 	if execErr != nil {
 		return "", nil, nil, execErr
 	}
@@ -154,12 +155,52 @@ func (a *GraphAgent) ProcessCommandWithClarification(
 	}
 }
 
-// SetModel updates the model name.
-// Note: This is a simplified implementation that only updates the model name string.
-// For full model switching functionality, the graph and LLM client need to be recreated.
+// SetModel switches to a different model by re-creating the LLM client and graph.
 func (a *GraphAgent) SetModel(modelName string) error {
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	provider, modelID, err := cfg.GetModelProvider(modelName)
+	if err != nil {
+		return fmt.Errorf("failed to parse model: %w", err)
+	}
+
+	providerCfg, ok := cfg.Models.Providers[provider]
+	if !ok {
+		return fmt.Errorf("provider not configured: %s", provider)
+	}
+
+	newLLM, err := llm.NewClient(provider, modelID, providerCfg)
+	if err != nil {
+		return fmt.Errorf("failed to create LLM client: %w", err)
+	}
+
+	a.mu.RLock()
+	currentDeps := a.deps
+	a.mu.RUnlock()
+
+	newDeps := &workflow.Dependencies{
+		K8sClient:        currentDeps.K8sClient,
+		LLM:              newLLM,
+		ModelName:        modelName,
+		ToolRegistry:     currentDeps.ToolRegistry,
+		PromptLoader:     currentDeps.PromptLoader,
+		SubGraphMgr:      currentDeps.SubGraphMgr,
+		ContextMgr:       currentDeps.ContextMgr,
+		SuggestionEngine: currentDeps.SuggestionEngine,
+	}
+
+	newGraph, err := workflow.NewK8sWizardGraph(newDeps)
+	if err != nil {
+		return fmt.Errorf("failed to reinitialize workflow graph: %w", err)
+	}
+
 	a.mu.Lock()
 	defer a.mu.Unlock()
+	a.graph = newGraph
+	a.deps = newDeps
 	a.modelName = modelName
 	return nil
 }
@@ -219,9 +260,9 @@ func NewGraphAgentWithCheckpointer(k8sClient k8s.Client, llmClient llm.Client, m
 		ModelName:    modelName,
 		ToolRegistry: tools.NewRegistry(),
 		// PromptLoader, SubGraphMgr, ContextMgr will be initialized in later phases
-		PromptLoader: nil,
-		SubGraphMgr:  nil,
-		ContextMgr:   nil,
+		PromptLoader:     nil,
+		SubGraphMgr:      nil,
+		ContextMgr:       nil,
 		SuggestionEngine: suggestionEngine,
 	}
 
@@ -260,6 +301,7 @@ func (a *GraphAgentWithCheckpointer) ProcessCommandWithClarificationAndThread(
 ) (result string, clarification *models.ClarificationRequest, actionPreview *models.ActionPreview, err error) {
 	a.mu.RLock()
 	modelName := a.modelName
+	graph := a.graph
 	a.mu.RUnlock()
 
 	// Build initial state
@@ -278,9 +320,9 @@ func (a *GraphAgentWithCheckpointer) ProcessCommandWithClarificationAndThread(
 	if threadID != "" {
 		// Use thread-aware configuration
 		config := lgg.WithThreadID(threadID)
-		finalState, execErr = a.graph.InvokeWithConfig(ctx, initialState, config)
+		finalState, execErr = graph.InvokeWithConfig(ctx, initialState, config)
 	} else {
-		finalState, execErr = a.graph.Invoke(ctx, initialState)
+		finalState, execErr = graph.Invoke(ctx, initialState)
 	}
 
 	if execErr != nil {
@@ -327,10 +369,53 @@ func (a *GraphAgentWithCheckpointer) ProcessCommandWithClarificationAndThread(
 	}
 }
 
-// SetModel updates the model name.
+// SetModel switches to a different model by re-creating the LLM client and graph.
 func (a *GraphAgentWithCheckpointer) SetModel(modelName string) error {
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	provider, modelID, err := cfg.GetModelProvider(modelName)
+	if err != nil {
+		return fmt.Errorf("failed to parse model: %w", err)
+	}
+
+	providerCfg, ok := cfg.Models.Providers[provider]
+	if !ok {
+		return fmt.Errorf("provider not configured: %s", provider)
+	}
+
+	newLLM, err := llm.NewClient(provider, modelID, providerCfg)
+	if err != nil {
+		return fmt.Errorf("failed to create LLM client: %w", err)
+	}
+
+	a.mu.RLock()
+	currentDeps := a.deps
+	checkpointer := a.checkpointer
+	a.mu.RUnlock()
+
+	newDeps := &workflow.Dependencies{
+		K8sClient:        currentDeps.K8sClient,
+		LLM:              newLLM,
+		ModelName:        modelName,
+		ToolRegistry:     currentDeps.ToolRegistry,
+		PromptLoader:     currentDeps.PromptLoader,
+		SubGraphMgr:      currentDeps.SubGraphMgr,
+		ContextMgr:       currentDeps.ContextMgr,
+		SuggestionEngine: currentDeps.SuggestionEngine,
+	}
+
+	newGraph, err := workflow.NewK8sWizardGraphWithCheckpointer(newDeps, checkpointer.GetStore())
+	if err != nil {
+		return fmt.Errorf("failed to reinitialize workflow graph: %w", err)
+	}
+
 	a.mu.Lock()
 	defer a.mu.Unlock()
+	a.graph = newGraph
+	a.deps = newDeps
 	a.modelName = modelName
 	return nil
 }

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -80,18 +80,35 @@ func TestGraphAgent_GetModel(t *testing.T) {
 }
 
 func TestGraphAgent_SetModel(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("DEEPSEEK_API_KEY", "test-key")
+
 	agent, err := NewGraphAgent(nil, &mockLLMClient{}, "initial-model")
 	if err != nil {
 		t.Fatalf("failed to create agent: %v", err)
 	}
 
-	err = agent.SetModel("new-model")
+	err = agent.SetModel("deepseek/deepseek-chat")
 	if err != nil {
 		t.Fatalf("SetModel() error = %v", err)
 	}
 
-	if agent.GetModelName() != "new-model" {
-		t.Errorf("GetModelName() = %q, want %q", agent.GetModelName(), "new-model")
+	if agent.GetModelName() != "deepseek/deepseek-chat" {
+		t.Errorf("GetModelName() = %q, want %q", agent.GetModelName(), "deepseek/deepseek-chat")
+	}
+}
+
+func TestGraphAgent_SetModel_InvalidModel(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	agent, err := NewGraphAgent(nil, &mockLLMClient{}, "initial-model")
+	if err != nil {
+		t.Fatalf("failed to create agent: %v", err)
+	}
+
+	err = agent.SetModel("invalid-model")
+	if err == nil {
+		t.Fatal("expected SetModel() to fail for invalid model format")
 	}
 }
 
@@ -393,6 +410,9 @@ func TestGraphAgentWithCheckpointer_GetModel(t *testing.T) {
 }
 
 func TestGraphAgentWithCheckpointer_SetModel(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("DEEPSEEK_API_KEY", "test-key")
+
 	checkpointer, err := workflow.NewCheckpointerManager(t.TempDir())
 	if err != nil {
 		t.Fatalf("failed to create checkpointer: %v", err)
@@ -404,13 +424,13 @@ func TestGraphAgentWithCheckpointer_SetModel(t *testing.T) {
 		t.Fatalf("failed to create agent: %v", err)
 	}
 
-	err = agent.SetModel("new-model")
+	err = agent.SetModel("deepseek/deepseek-chat")
 	if err != nil {
 		t.Fatalf("SetModel() error = %v", err)
 	}
 
-	if agent.GetModelName() != "new-model" {
-		t.Errorf("GetModelName() = %q, want %q", agent.GetModelName(), "new-model")
+	if agent.GetModelName() != "deepseek/deepseek-chat" {
+		t.Errorf("GetModelName() = %q, want %q", agent.GetModelName(), "deepseek/deepseek-chat")
 	}
 }
 

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -5,6 +5,8 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"regexp"
+	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -34,7 +36,7 @@ type Client interface {
 	GetPodLogs(ctx context.Context, namespace, pod, container string, tailLines int64) (string, error)
 
 	// ExecPod executes a command in a pod's container.
-	ExecPod(ctx context.Context, namespace, pod, container, command string) (string, error)
+	ExecPod(ctx context.Context, namespace, pod, container string, command []string) (string, error)
 }
 
 // KubernetesClient implements Client using kubernetes.Interface.
@@ -296,8 +298,10 @@ func (c *KubernetesClient) GetPodLogs(ctx context.Context, namespace string, pod
 	return buf.String(), nil
 }
 
+var dangerousShellPattern = regexp.MustCompile(`[;&|` + "`" + `$<>]|\$\(|\r|\n`)
+
 // ExecPod executes a command in a pod.
-func (c *KubernetesClient) ExecPod(ctx context.Context, namespace string, pod string, container string, command string) (string, error) {
+func (c *KubernetesClient) ExecPod(ctx context.Context, namespace string, pod string, container string, command []string) (string, error) {
 	// Validate parameters
 	if namespace == "" {
 		return "", fmt.Errorf("namespace cannot be empty")
@@ -308,17 +312,25 @@ func (c *KubernetesClient) ExecPod(ctx context.Context, namespace string, pod st
 	if container == "" {
 		return "", fmt.Errorf("container cannot be empty")
 	}
-	if command == "" {
+	if len(command) == 0 {
 		return "", fmt.Errorf("command cannot be empty")
+	}
+	for i, arg := range command {
+		if strings.TrimSpace(arg) == "" {
+			return "", fmt.Errorf("command argument at index %d cannot be empty", i)
+		}
+		if strings.ContainsRune(arg, '\x00') {
+			return "", fmt.Errorf("command argument at index %d contains null byte", i)
+		}
+	}
+	if isShellCommand(command) && dangerousShellPattern.MatchString(command[2]) {
+		return "", fmt.Errorf("unsafe shell command rejected")
 	}
 
 	// Check config is available for SPDY executor
 	if c.config == nil {
 		return "", fmt.Errorf("client config is nil, cannot execute pod commands")
 	}
-
-	// Split command into args (simple shell -c wrapper)
-	args := []string{"sh", "-c", command}
 
 	// Build exec request
 	req := c.clientset.CoreV1().RESTClient().Post().
@@ -328,7 +340,7 @@ func (c *KubernetesClient) ExecPod(ctx context.Context, namespace string, pod st
 		SubResource("exec").
 		VersionedParams(&corev1.PodExecOptions{
 			Container: container,
-			Command:   args,
+			Command:   command,
 			Stdin:     false,
 			Stdout:    true,
 			Stderr:    true,
@@ -355,4 +367,17 @@ func (c *KubernetesClient) ExecPod(ctx context.Context, namespace string, pod st
 	}
 
 	return buf.String(), nil
+}
+
+func isShellCommand(command []string) bool {
+	if len(command) < 3 {
+		return false
+	}
+
+	switch command[0] {
+	case "sh", "bash", "zsh", "dash", "ksh", "ash":
+		return command[1] == "-c"
+	default:
+		return false
+	}
 }

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -26,6 +26,9 @@ type Client interface {
 	// If namespace is empty, lists resources across all namespaces.
 	GetResources(ctx context.Context, namespace, resourceType string) (string, error)
 
+	// ListDeployments returns structured deployment objects for matching and routing logic.
+	ListDeployments(ctx context.Context, namespace string) (*appsv1.DeploymentList, error)
+
 	// ScaleDeployment scales a deployment to the specified number of replicas.
 	ScaleDeployment(ctx context.Context, namespace, name string, replicas int32) (string, error)
 
@@ -158,6 +161,15 @@ func (c *KubernetesClient) getDeployments(ctx context.Context, namespace string,
 		}
 	}
 	return result, nil
+}
+
+// ListDeployments returns structured deployment objects.
+func (c *KubernetesClient) ListDeployments(ctx context.Context, namespace string) (*appsv1.DeploymentList, error) {
+	deps, err := c.clientset.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("get deployment list failed: %w", err)
+	}
+	return deps, nil
 }
 
 func (c *KubernetesClient) getServices(ctx context.Context, namespace string, allNamespaces bool) (string, error) {

--- a/pkg/k8s/client_test.go
+++ b/pkg/k8s/client_test.go
@@ -482,7 +482,7 @@ func TestExecPod(t *testing.T) {
 
 	// Note: fake client doesn't support exec, so this will fail
 	// The implementation should handle this gracefully
-	_, err := client.ExecPod(ctx, "test-ns", "test-pod", "echo test", "")
+	_, err := client.ExecPod(ctx, "test-ns", "test-pod", "", []string{"echo", "test"})
 	// We expect this to fail with fake client
 	if err == nil {
 		t.Error("expected error with fake client for exec")
@@ -495,7 +495,7 @@ func TestExecPod_NilConfig(t *testing.T) {
 	client := NewClient(fakeClient, nil)
 
 	// Test that ExecPod with nil config returns proper error
-	_, err := client.ExecPod(ctx, "test-ns", "test-pod", "test-container", "echo test")
+	_, err := client.ExecPod(ctx, "test-ns", "test-pod", "test-container", []string{"echo", "test"})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "config is nil")
 }
@@ -510,7 +510,7 @@ func TestExecPod_ValidationErrors(t *testing.T) {
 		namespace string
 		pod       string
 		container string
-		command   string
+		command   []string
 		wantErr   bool
 		errMsg    string
 	}{
@@ -519,7 +519,7 @@ func TestExecPod_ValidationErrors(t *testing.T) {
 			namespace: "",
 			pod:       "test-pod",
 			container: "test-container",
-			command:   "echo test",
+			command:   []string{"echo", "test"},
 			wantErr:   true,
 			errMsg:    "namespace cannot be empty",
 		},
@@ -528,7 +528,7 @@ func TestExecPod_ValidationErrors(t *testing.T) {
 			namespace: "test-ns",
 			pod:       "",
 			container: "test-container",
-			command:   "echo test",
+			command:   []string{"echo", "test"},
 			wantErr:   true,
 			errMsg:    "pod name cannot be empty",
 		},
@@ -537,7 +537,7 @@ func TestExecPod_ValidationErrors(t *testing.T) {
 			namespace: "test-ns",
 			pod:       "test-pod",
 			container: "",
-			command:   "echo test",
+			command:   []string{"echo", "test"},
 			wantErr:   true,
 			errMsg:    "container cannot be empty",
 		},
@@ -546,9 +546,18 @@ func TestExecPod_ValidationErrors(t *testing.T) {
 			namespace: "test-ns",
 			pod:       "test-pod",
 			container: "test-container",
-			command:   "",
+			command:   []string{},
 			wantErr:   true,
 			errMsg:    "command cannot be empty",
+		},
+		{
+			name:      "unsafe shell command",
+			namespace: "test-ns",
+			pod:       "test-pod",
+			container: "test-container",
+			command:   []string{"sh", "-c", "echo ok; rm -rf /"},
+			wantErr:   true,
+			errMsg:    "unsafe shell command rejected",
 		},
 	}
 

--- a/pkg/workflow/context.go
+++ b/pkg/workflow/context.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -13,17 +14,17 @@ const checkpointMaxHistoryEntries = 200
 
 // ConversationContext maintains conversation history and context.
 type ConversationContext struct {
-	ThreadID       string
-	History        []ConversationEntry
-	LastOperation  *K8sAction
-	LastResource   string
+	ThreadID      string
+	History       []ConversationEntry
+	LastOperation *K8sAction
+	LastResource  string
 	LastNamespace string
 	Timestamp     time.Time
 }
 
 // ConversationEntry represents a single conversation turn.
 type ConversationEntry struct {
-	Role      string    // "user" or "assistant"
+	Role      string // "user" or "assistant"
 	Content   string
 	Action    *K8sAction
 	Timestamp time.Time
@@ -31,24 +32,32 @@ type ConversationEntry struct {
 
 // ContextManager manages conversation contexts per thread.
 type ContextManager struct {
-	contexts    map[string]*ConversationContext
+	mu           sync.RWMutex
+	contexts     map[string]*ConversationContext
 	checkpointer *CheckpointerManager
 }
 
 // NewContextManager creates a context manager.
 func NewContextManager(checkpointer *CheckpointerManager) (*ContextManager, error) {
 	return &ContextManager{
-		contexts:    make(map[string]*ConversationContext),
+		contexts:     make(map[string]*ConversationContext),
 		checkpointer: checkpointer,
 	}, nil
 }
 
 // Get retrieves or creates a conversation context.
 func (m *ContextManager) Get(threadID string) *ConversationContext {
-	if ctx, exists := m.contexts[threadID]; exists {
-		// Update timestamp
-		ctx.Timestamp = time.Now()
-		return ctx
+	m.mu.RLock()
+	_, exists := m.contexts[threadID]
+	m.mu.RUnlock()
+	if exists {
+		m.mu.Lock()
+		if current, ok := m.contexts[threadID]; ok {
+			current.Timestamp = time.Now()
+			m.mu.Unlock()
+			return current
+		}
+		m.mu.Unlock()
 	}
 
 	// Try to load from checkpoint
@@ -60,14 +69,21 @@ func (m *ContextManager) Get(threadID string) *ConversationContext {
 		}
 	}
 
-	ctx := &ConversationContext{
+	newCtx := &ConversationContext{
 		ThreadID:  threadID,
 		History:   history,
 		Timestamp: time.Now(),
 	}
 
-	m.contexts[threadID] = ctx
-	return ctx
+	m.mu.Lock()
+	if existing, ok := m.contexts[threadID]; ok {
+		existing.Timestamp = time.Now()
+		m.mu.Unlock()
+		return existing
+	}
+	m.contexts[threadID] = newCtx
+	m.mu.Unlock()
+	return newCtx
 }
 
 // AddEntry adds an entry to conversation history.
@@ -81,6 +97,7 @@ func (m *ContextManager) AddEntry(threadID string, entry ConversationEntry) erro
 	}
 
 	ctx := m.Get(threadID)
+	m.mu.Lock()
 	ctx.History = append(ctx.History, entry)
 	ctx.Timestamp = time.Now()
 
@@ -90,6 +107,7 @@ func (m *ContextManager) AddEntry(threadID string, entry ConversationEntry) erro
 		ctx.LastResource = entry.Action.Resource
 		ctx.LastNamespace = entry.Action.Namespace
 	}
+	m.mu.Unlock()
 
 	// Persist to checkpoint if available
 	if m.checkpointer != nil {
@@ -104,12 +122,18 @@ func (m *ContextManager) AddEntry(threadID string, entry ConversationEntry) erro
 // GetContextString returns formatted context for LLM.
 func (m *ContextManager) GetContextString(threadID string, maxHistory int) string {
 	ctx := m.Get(threadID)
+	m.mu.RLock()
+	historyCopy := append([]ConversationEntry(nil), ctx.History...)
+	lastOperation := ctx.LastOperation
+	lastNamespace := ctx.LastNamespace
+	lastResource := ctx.LastResource
+	m.mu.RUnlock()
 
 	var sb strings.Builder
 	sb.WriteString("对话历史:\n")
 
 	// Get recent history
-	history := ctx.History
+	history := historyCopy
 	if len(history) > maxHistory {
 		history = history[len(history)-maxHistory:]
 	}
@@ -123,11 +147,11 @@ func (m *ContextManager) GetContextString(threadID string, maxHistory int) strin
 	}
 
 	// Add context from last operation
-	if ctx.LastOperation != nil {
+	if lastOperation != nil {
 		sb.WriteString(fmt.Sprintf("\n最近操作: %s %s/%s\n",
-			ctx.LastOperation.Action,
-			ctx.LastNamespace,
-			ctx.LastResource))
+			lastOperation.Action,
+			lastNamespace,
+			lastResource))
 	}
 
 	return sb.String()
@@ -136,13 +160,17 @@ func (m *ContextManager) GetContextString(threadID string, maxHistory int) strin
 // Clear removes conversation context from memory only.
 // The checkpoint data is preserved and can be reloaded via Get().
 func (m *ContextManager) Clear(threadID string) error {
+	m.mu.Lock()
 	delete(m.contexts, threadID)
+	m.mu.Unlock()
 	return nil
 }
 
 // HasContext checks if a context exists without creating one.
 func (m *ContextManager) HasContext(threadID string) bool {
+	m.mu.RLock()
 	_, exists := m.contexts[threadID]
+	m.mu.RUnlock()
 	return exists
 }
 
@@ -199,10 +227,19 @@ func (m *ContextManager) saveToCheckpoint(threadID string) error {
 		return nil
 	}
 
+	m.mu.RLock()
 	ctx := m.contexts[threadID]
 	if ctx == nil {
+		m.mu.RUnlock()
 		return fmt.Errorf("context not found for thread %s", threadID)
 	}
+	var entry ConversationEntry
+	hasEntry := false
+	if len(ctx.History) > 0 {
+		entry = ctx.History[len(ctx.History)-1]
+		hasEntry = true
+	}
+	m.mu.RUnlock()
 
 	// Ensure conversation_history table exists with auto-increment ID to prevent timestamp collisions.
 	_, err := m.checkpointer.db.Exec(`
@@ -228,12 +265,11 @@ func (m *ContextManager) saveToCheckpoint(threadID string) error {
 		return fmt.Errorf("failed to create unique index: %w", err)
 	}
 
-	if len(ctx.History) == 0 {
+	if !hasEntry {
 		return nil
 	}
 
 	// Persist only the newest entry to avoid O(n^2) checkpoint writes.
-	entry := ctx.History[len(ctx.History)-1]
 	timestamp := entry.Timestamp
 	if timestamp.IsZero() {
 		timestamp = time.Now()

--- a/pkg/workflow/context.go
+++ b/pkg/workflow/context.go
@@ -9,6 +9,8 @@ import (
 	"time"
 )
 
+const checkpointMaxHistoryEntries = 200
+
 // ConversationContext maintains conversation history and context.
 type ConversationContext struct {
 	ThreadID       string
@@ -202,7 +204,7 @@ func (m *ContextManager) saveToCheckpoint(threadID string) error {
 		return fmt.Errorf("context not found for thread %s", threadID)
 	}
 
-	// Ensure conversation_history table exists with auto-increment ID to prevent timestamp collisions
+	// Ensure conversation_history table exists with auto-increment ID to prevent timestamp collisions.
 	_, err := m.checkpointer.db.Exec(`
 		CREATE TABLE IF NOT EXISTS conversation_history (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -217,27 +219,60 @@ func (m *ContextManager) saveToCheckpoint(threadID string) error {
 		return fmt.Errorf("failed to create table: %w", err)
 	}
 
-	// Save all entries
-	for _, entry := range ctx.History {
-		var actionJSON string
-		if entry.Action != nil {
-			// Serialize all 7 K8sAction fields using encoding/json
-			actionBytes, err := json.Marshal(entry.Action)
-			if err != nil {
-				log.Printf("ERROR: Failed to serialize action for thread %s: %v", threadID, err)
-				continue
-			}
+	// Add a unique index so retries/re-saves do not duplicate the same entry.
+	_, err = m.checkpointer.db.Exec(`
+		CREATE UNIQUE INDEX IF NOT EXISTS idx_conversation_history_unique_entry
+		ON conversation_history (thread_id, role, content, timestamp)
+	`)
+	if err != nil {
+		return fmt.Errorf("failed to create unique index: %w", err)
+	}
+
+	if len(ctx.History) == 0 {
+		return nil
+	}
+
+	// Persist only the newest entry to avoid O(n^2) checkpoint writes.
+	entry := ctx.History[len(ctx.History)-1]
+	timestamp := entry.Timestamp
+	if timestamp.IsZero() {
+		timestamp = time.Now()
+	}
+
+	var actionJSON string
+	if entry.Action != nil {
+		// Serialize all 7 K8sAction fields using encoding/json.
+		actionBytes, marshalErr := json.Marshal(entry.Action)
+		if marshalErr != nil {
+			log.Printf("ERROR: Failed to serialize action for thread %s: %v", threadID, marshalErr)
+		} else {
 			actionJSON = string(actionBytes)
 		}
+	}
 
-		_, err := m.checkpointer.db.Exec(`
-			INSERT INTO conversation_history
-			(thread_id, role, content, timestamp, action_json)
-			VALUES (?, ?, ?, ?, ?)
-		`, threadID, entry.Role, entry.Content, entry.Timestamp.Format(time.RFC3339), actionJSON)
-		if err != nil {
-			return fmt.Errorf("failed to save conversation entry for thread %s: %w", threadID, err)
-		}
+	_, err = m.checkpointer.db.Exec(`
+		INSERT OR IGNORE INTO conversation_history
+		(thread_id, role, content, timestamp, action_json)
+		VALUES (?, ?, ?, ?, ?)
+	`, threadID, entry.Role, entry.Content, timestamp.Format(time.RFC3339), actionJSON)
+	if err != nil {
+		return fmt.Errorf("failed to save conversation entry for thread %s: %w", threadID, err)
+	}
+
+	// Prune old entries for the thread, keeping only the most recent N rows.
+	_, err = m.checkpointer.db.Exec(`
+		DELETE FROM conversation_history
+		WHERE thread_id = ?
+		AND id NOT IN (
+			SELECT id
+			FROM conversation_history
+			WHERE thread_id = ?
+			ORDER BY timestamp DESC, id DESC
+			LIMIT ?
+		)
+	`, threadID, threadID, checkpointMaxHistoryEntries)
+	if err != nil {
+		return fmt.Errorf("failed to prune conversation history for thread %s: %w", threadID, err)
 	}
 
 	return nil

--- a/pkg/workflow/e2e_suggestions_test.go
+++ b/pkg/workflow/e2e_suggestions_test.go
@@ -2,9 +2,12 @@ package workflow
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"k8s-wizard/api/models"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // MockK8sClient simulates a Kubernetes client for testing
@@ -21,6 +24,34 @@ func (m *MockK8sClient) GetResources(ctx context.Context, namespace, resourceTyp
 		return m.deployments, nil
 	}
 	return "", nil
+}
+
+func (m *MockK8sClient) ListDeployments(ctx context.Context, namespace string) (*appsv1.DeploymentList, error) {
+	var items []appsv1.Deployment
+	lines := strings.Split(m.deployments, "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "• ") {
+			continue
+		}
+
+		namePart := strings.TrimPrefix(line, "• ")
+		if idx := strings.Index(namePart, " ("); idx > 0 {
+			namePart = namePart[:idx]
+		}
+		namePart = strings.TrimSpace(namePart)
+		if namePart == "" {
+			continue
+		}
+
+		items = append(items, appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      namePart,
+				Namespace: namespace,
+			},
+		})
+	}
+	return &appsv1.DeploymentList{Items: items}, nil
 }
 
 func (m *MockK8sClient) ScaleDeployment(ctx context.Context, namespace, name string, replicas int32) (string, error) {

--- a/pkg/workflow/e2e_suggestions_test.go
+++ b/pkg/workflow/e2e_suggestions_test.go
@@ -35,7 +35,7 @@ func (m *MockK8sClient) GetPodLogs(ctx context.Context, namespace, pod, containe
 	return "", nil
 }
 
-func (m *MockK8sClient) ExecPod(ctx context.Context, namespace, pod, container, command string) (string, error) {
+func (m *MockK8sClient) ExecPod(ctx context.Context, namespace, pod, container string, command []string) (string, error) {
 	return "", nil
 }
 

--- a/pkg/workflow/routing.go
+++ b/pkg/workflow/routing.go
@@ -18,13 +18,8 @@ func RouteAfterParse(ctx context.Context, state AgentState) string {
 		return lgg.END
 	}
 
-	// If suggestions available, show them instead of form
-	if len(state.Suggestions) > 0 {
-		return "show_suggestions"
-	}
-
-	// Otherwise, proceed to merge form data
-	return "merge_form"
+	// Generate suggestions first, then proceed based on generated state.
+	return "show_suggestions"
 }
 
 // RouteAfterClarify determines the next node after checking clarification.

--- a/pkg/workflow/routing_test.go
+++ b/pkg/workflow/routing_test.go
@@ -30,7 +30,7 @@ func TestRouteAfterParse(t *testing.T) {
 			expected: "END",
 		},
 		{
-			name: "K8s operation with form data - merge_form",
+			name: "K8s operation with form data - show_suggestions",
 			state: AgentState{
 				Status:         StatusPending,
 				IsK8sOperation: true,
@@ -40,10 +40,10 @@ func TestRouteAfterParse(t *testing.T) {
 					Resource: "deployment",
 				},
 			},
-			expected: "merge_form",
+			expected: "show_suggestions",
 		},
 		{
-			name: "K8s operation without form data - merge_form",
+			name: "K8s operation without form data - show_suggestions",
 			state: AgentState{
 				Status:         StatusPending,
 				IsK8sOperation: true,
@@ -53,10 +53,10 @@ func TestRouteAfterParse(t *testing.T) {
 					Resource: "deployment",
 				},
 			},
-			expected: "merge_form",
+			expected: "show_suggestions",
 		},
 		{
-			name: "get action - merge_form",
+			name: "get action - show_suggestions",
 			state: AgentState{
 				Status:         StatusPending,
 				IsK8sOperation: true,
@@ -65,7 +65,7 @@ func TestRouteAfterParse(t *testing.T) {
 					Resource: "pod",
 				},
 			},
-			expected: "merge_form",
+			expected: "show_suggestions",
 		},
 		{
 			name: "K8s operation with suggestions - show_suggestions",

--- a/pkg/workflow/suggestions.go
+++ b/pkg/workflow/suggestions.go
@@ -11,6 +11,7 @@ import (
 	"k8s-wizard/api/models"
 	"k8s-wizard/pkg/k8s"
 	"k8s-wizard/pkg/logger"
+	appsv1 "k8s.io/api/apps/v1"
 )
 
 const suggestionCacheMaxSize = 256
@@ -49,8 +50,8 @@ func (e *SuggestionEngine) QueryCluster(ctx context.Context, req models.Suggesti
 		return cached, nil
 	}
 
-	// Query cluster resources
-	deployments, err := e.client.GetResources(ctx, req.Namespace, "deployment")
+	// Query structured deployment objects
+	deployments, err := e.client.ListDeployments(ctx, req.Namespace)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query deployments: %w", err)
 	}
@@ -60,7 +61,7 @@ func (e *SuggestionEngine) QueryCluster(ctx context.Context, req models.Suggesti
 
 	// If name is specified, find matches
 	if req.Name != "" {
-		matches := findNameMatches(req.Name, deployments)
+		matches := findNameMatches(req, deployments.Items)
 		suggestions = append(suggestions, matches...)
 	} else {
 		// Name not specified, suggest "Specify name" option
@@ -176,49 +177,34 @@ func MakeSuggestionsNode(engine *SuggestionEngine) NodeFunc {
 	}
 }
 
-func findNameMatches(name string, deployments string) []models.Suggestion {
+func findNameMatches(req models.SuggestionRequest, deployments []appsv1.Deployment) []models.Suggestion {
 	var matches []models.Suggestion
 
-	// Parse deployment names from the formatted output
-	lines := strings.Split(deployments, "\n")
-	for _, line := range lines {
-		if strings.Contains(line, "•") {
-			// Extract deployment name from line format:
-			// "  • nginx-deployment (副本: 3/3)"
-			parts := strings.Fields(line)
-			if len(parts) >= 2 {
-				depName := strings.TrimPrefix(parts[1], "[default]")
-				depName = strings.TrimSpace(depName)
+	for _, dep := range deployments {
+		depName := dep.Name
 
-				// Calculate confidence based on match type
-				confidence := 0.0
-				isExisting := true
+		// Calculate confidence based on match type
+		confidence := 0.0
+		if depName == req.Name {
+			// Exact match
+			confidence = 1.0
+		} else if strings.Contains(strings.ToLower(depName), strings.ToLower(req.Name)) ||
+			strings.Contains(strings.ToLower(req.Name), strings.ToLower(depName)) {
+			// Partial match
+			confidence = 0.6
+		}
 
-				if depName == name {
-					// Exact match
-					confidence = 1.0
-				} else if strings.Contains(strings.ToLower(depName), strings.ToLower(name)) ||
-					strings.Contains(strings.ToLower(name), strings.ToLower(depName)) {
-					// Partial match
-					confidence = 0.6
-				} else {
-					// No match
-					isExisting = false
-				}
-
-				if confidence > 0 {
-					matches = append(matches, models.Suggestion{
-						Type:       "reuse",
-						Action:     "create",
-						Resource:   "deployment",
-						Name:       depName,
-						Namespace:  "default",
-						Reason:     fmt.Sprintf("Found existing deployment with similar name"),
-						Confidence: confidence,
-						Existing:   isExisting,
-					})
-				}
-			}
+		if confidence > 0 {
+			matches = append(matches, models.Suggestion{
+				Type:       "reuse",
+				Action:     req.Action,
+				Resource:   req.Resource,
+				Name:       depName,
+				Namespace:  dep.Namespace,
+				Reason:     "Found existing deployment with similar name",
+				Confidence: confidence,
+				Existing:   true,
+			})
 		}
 	}
 
@@ -226,11 +212,11 @@ func findNameMatches(name string, deployments string) []models.Suggestion {
 	if len(matches) == 0 {
 		matches = append(matches, models.Suggestion{
 			Type:       "create",
-			Action:     "create",
-			Resource:   "deployment",
-			Name:       name,
-			Namespace:  "default",
-			Reason:     fmt.Sprintf("Create new deployment named '%s'", name),
+			Action:     req.Action,
+			Resource:   req.Resource,
+			Name:       req.Name,
+			Namespace:  req.Namespace,
+			Reason:     fmt.Sprintf("Create new deployment named '%s'", req.Name),
 			Confidence: 1.0,
 			Existing:   false,
 		})

--- a/pkg/workflow/suggestions.go
+++ b/pkg/workflow/suggestions.go
@@ -1,6 +1,7 @@
 package workflow
 
 import (
+	"container/list"
 	"context"
 	"fmt"
 	"strings"
@@ -12,29 +13,38 @@ import (
 	"k8s-wizard/pkg/logger"
 )
 
+const suggestionCacheMaxSize = 256
+
+type suggestionCacheEntry struct {
+	suggestions []models.Suggestion
+	cachedAt    time.Time
+}
+
 type SuggestionEngine struct {
-	client    k8s.Client
-	cache     map[string][]models.Suggestion
+	client     k8s.Client
+	cache      map[string]suggestionCacheEntry
+	cacheOrder *list.List
+	cacheIndex map[string]*list.Element
 	cacheMutex sync.RWMutex
-	cacheTTL  time.Duration
+	cacheTTL   time.Duration
+	cacheLimit int
 }
 
 func NewSuggestionEngine(client k8s.Client) *SuggestionEngine {
 	return &SuggestionEngine{
-		client:    client,
-		cache:     make(map[string][]models.Suggestion),
-		cacheTTL: 5 * time.Second,
+		client:     client,
+		cache:      make(map[string]suggestionCacheEntry),
+		cacheOrder: list.New(),
+		cacheIndex: make(map[string]*list.Element),
+		cacheTTL:   5 * time.Second,
+		cacheLimit: suggestionCacheMaxSize,
 	}
 }
 
 func (e *SuggestionEngine) QueryCluster(ctx context.Context, req models.SuggestionRequest) ([]models.Suggestion, error) {
 	// Check cache first
 	cacheKey := buildCacheKey(req)
-	e.cacheMutex.RLock()
-	cached, found := e.cache[cacheKey]
-	e.cacheMutex.RUnlock()
-
-	if found {
+	if cached, found := e.getCachedSuggestions(cacheKey); found {
 		logger.Debug("cache hit for suggestions", "key", cacheKey)
 		return cached, nil
 	}
@@ -50,7 +60,7 @@ func (e *SuggestionEngine) QueryCluster(ctx context.Context, req models.Suggesti
 
 	// If name is specified, find matches
 	if req.Name != "" {
-		matches := findNameMatches(req.Name, deployments, e.cache)
+		matches := findNameMatches(req.Name, deployments)
 		suggestions = append(suggestions, matches...)
 	} else {
 		// Name not specified, suggest "Specify name" option
@@ -67,15 +77,75 @@ func (e *SuggestionEngine) QueryCluster(ctx context.Context, req models.Suggesti
 	}
 
 	// Store in cache
-	e.cacheMutex.Lock()
-	e.cache[cacheKey] = suggestions
-	e.cacheMutex.Unlock()
+	e.setCachedSuggestions(cacheKey, suggestions)
 
 	return suggestions, nil
 }
 
 func buildCacheKey(req models.SuggestionRequest) string {
 	return fmt.Sprintf("%s:%s:%s", req.Action, req.Namespace, req.Name)
+}
+
+func (e *SuggestionEngine) getCachedSuggestions(key string) ([]models.Suggestion, bool) {
+	now := time.Now()
+
+	e.cacheMutex.Lock()
+	defer e.cacheMutex.Unlock()
+
+	entry, found := e.cache[key]
+	if !found {
+		return nil, false
+	}
+
+	if now.Sub(entry.cachedAt) > e.cacheTTL {
+		e.removeCacheEntryLocked(key)
+		return nil, false
+	}
+
+	e.markCacheAsRecentLocked(key)
+	return entry.suggestions, true
+}
+
+func (e *SuggestionEngine) setCachedSuggestions(key string, suggestions []models.Suggestion) {
+	e.cacheMutex.Lock()
+	defer e.cacheMutex.Unlock()
+
+	e.cache[key] = suggestionCacheEntry{
+		suggestions: suggestions,
+		cachedAt:    time.Now(),
+	}
+	e.markCacheAsRecentLocked(key)
+
+	for len(e.cache) > e.cacheLimit {
+		oldest := e.cacheOrder.Back()
+		if oldest == nil {
+			break
+		}
+
+		oldestKey, ok := oldest.Value.(string)
+		if !ok {
+			e.cacheOrder.Remove(oldest)
+			continue
+		}
+		e.removeCacheEntryLocked(oldestKey)
+	}
+}
+
+func (e *SuggestionEngine) markCacheAsRecentLocked(key string) {
+	if elem, exists := e.cacheIndex[key]; exists {
+		e.cacheOrder.MoveToFront(elem)
+		return
+	}
+
+	e.cacheIndex[key] = e.cacheOrder.PushFront(key)
+}
+
+func (e *SuggestionEngine) removeCacheEntryLocked(key string) {
+	delete(e.cache, key)
+	if elem, exists := e.cacheIndex[key]; exists {
+		e.cacheOrder.Remove(elem)
+		delete(e.cacheIndex, key)
+	}
 }
 
 // MakeSuggestionsNode creates a workflow node that generates suggestions based on parsed intent
@@ -106,7 +176,7 @@ func MakeSuggestionsNode(engine *SuggestionEngine) NodeFunc {
 	}
 }
 
-func findNameMatches(name string, deployments string, cache map[string][]models.Suggestion) []models.Suggestion {
+func findNameMatches(name string, deployments string) []models.Suggestion {
 	var matches []models.Suggestion
 
 	// Parse deployment names from the formatted output

--- a/pkg/workflow/suggestions_test.go
+++ b/pkg/workflow/suggestions_test.go
@@ -5,10 +5,14 @@ import (
 	"testing"
 
 	"k8s-wizard/api/models"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // MockClient for testing
-type MockClient struct{}
+type MockClient struct {
+	deployments []appsv1.Deployment
+}
 
 func (m *MockClient) CreateDeployment(ctx context.Context, namespace, name, image string, replicas int32) (string, error) {
 	return "", nil
@@ -19,6 +23,26 @@ func (m *MockClient) GetResources(ctx context.Context, namespace, resourceType s
 	return `🚀 集群中的 Deployment (共 2 个):
   • nginx-deployment (副本: 3/3)
   • nginx-ingress (副本: 2/2)`, nil
+}
+
+func (m *MockClient) ListDeployments(ctx context.Context, namespace string) (*appsv1.DeploymentList, error) {
+	if len(m.deployments) == 0 {
+		m.deployments = []appsv1.Deployment{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "nginx-deployment",
+					Namespace: "default",
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "nginx-ingress",
+					Namespace: "default",
+				},
+			},
+		}
+	}
+	return &appsv1.DeploymentList{Items: m.deployments}, nil
 }
 
 func (m *MockClient) ScaleDeployment(ctx context.Context, namespace, name string, replicas int32) (string, error) {

--- a/pkg/workflow/suggestions_test.go
+++ b/pkg/workflow/suggestions_test.go
@@ -33,7 +33,7 @@ func (m *MockClient) GetPodLogs(ctx context.Context, namespace, pod, container s
 	return "", nil
 }
 
-func (m *MockClient) ExecPod(ctx context.Context, namespace, pod, container, command string) (string, error) {
+func (m *MockClient) ExecPod(ctx context.Context, namespace, pod, container string, command []string) (string, error) {
 	return "", nil
 }
 

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { NavItem, QuickAction, Suggestion } from '../types';
+import { ChatResponse, NavItem, QuickAction, Suggestion } from '../types';
 import { Header } from '../components/Header';
 import { Sidebar } from '../components/Sidebar';
 import { MessageList } from '../components/MessageList';
@@ -7,6 +7,7 @@ import { QuickActions } from '../components/QuickActions';
 import { ChatInput } from '../components/ChatInput';
 import { useMessages } from '../hooks/useMessages';
 import { useConnectionStatus } from '../hooks/useConnectionStatus';
+import { api } from '../services/api';
 
 export const ChatPage: React.FC = () => {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
@@ -33,34 +34,21 @@ export const ChatPage: React.FC = () => {
     { label: '删除旧 Pod', command: '删除名为 old 的 pod' },
   ];
 
-  const sendMessage = async (content: string, formData?: Record<string, any>, confirm?: boolean) => {
+  const sendMessage = async (
+    content: string,
+    formData?: Record<string, any>,
+    confirm?: boolean
+  ): Promise<ChatResponse> => {
     setLoading(true);
     console.log('📤 发送请求:', { content, formData, confirm });
 
     try {
-      const response = await fetch('/api/chat', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ content, formData, confirm }),
-      });
-
-      // 检查响应状态
-      if (!response.ok) {
-        return { error: `服务器错误: ${response.status}` };
-      }
-
-      // 检查响应内容
-      const text = await response.text();
-      if (!text) {
-        return { error: '服务器返回空响应' };
-      }
-
-      const data = JSON.parse(text);
+      const data = await api.sendChat({ content, formData, confirm });
       console.log('📥 收到响应:', data);
       return data;
     } catch (error) {
       console.error('❌ 请求错误:', error);
-      return { error: error instanceof Error ? error.message : '网络错误，请检查后端服务' };
+      return { result: '', error: error instanceof Error ? error.message : '网络错误，请检查后端服务' };
     } finally {
       setLoading(false);
     }

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -44,11 +44,31 @@ export const api = {
     };
   },
 
+  // 发送聊天请求（支持表单补充与确认执行）
+  async sendChat(request: ChatRequest): Promise<ChatResponse> {
+    const response = await fetch(`${API_BASE}/chat`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(request),
+    });
+
+    if (!response.ok) {
+      const errorData = (await response.json()) as ChatResponse;
+      return { error: errorData.error || `服务器错误: ${response.status}`, result: '' };
+    }
+
+    return (await response.json()) as ChatResponse;
+  },
+
   // 获取资源
   async getResources(type: string = 'pod', namespace: string = 'default'): Promise<string> {
-    const response = await fetch(
-      `${API_BASE}/resources?type=${type}&namespace=${namespace}`
-    );
+    const params = new URLSearchParams({
+      type,
+      namespace,
+    });
+    const response = await fetch(`${API_BASE}/resources?${params.toString()}`);
 
     if (!response.ok) {
       const errorData = (await response.json()) as ChatResponse;


### PR DESCRIPTION
## Summary
- Add token-based authentication middleware
- Require auth for production environments, optional for local development
- Add authorization checks for dangerous operations (create/delete/scale)

## Changes
- `api/middleware/auth.go`: New authentication middleware
- `cmd/k8s-wizard/main.go`: Wire auth middleware to routes

## Configuration
- `K8S_WIZARD_ENV=production|prod`: Defaults auth to required
- `K8S_WIZARD_AUTH_REQUIRED=true|false`: Explicit override
- `K8S_WIZARD_API_TOKEN`: Authenticates regular API requests
- `K8S_WIZARD_ADMIN_TOKEN`: Required for dangerous chat operations

## Security Impact
Previously, destructive endpoints were exposed without authentication. This fix adds token-based auth with environment-controlled requirement.

Fixes #3