### PR TITLE
fix(security): address medium-risk security issues

### DIFF
--- a/api/handlers/config.go
+++ b/api/handlers/config.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	"k8s-wizard/api/models"
 	"k8s-wizard/pkg/agent"
@@ -118,7 +119,12 @@ func (h *ConfigHandler) SetModel(c *gin.Context) {
 
 	// 切换运行时模型（包含 client/graph 重建）
 	if err := h.agent.SetModel(req.Model); err != nil {
-		c.JSON(http.StatusInternalServerError, models.SetModelResponse{
+		status := http.StatusInternalServerError
+		if isInvalidModelError(err) {
+			status = http.StatusBadRequest
+		}
+
+		c.JSON(status, models.SetModelResponse{
 			Success: false,
 			Error:   "模型切换失败: " + err.Error(),
 		})
@@ -152,4 +158,24 @@ func (h *ConfigHandler) SetModel(c *gin.Context) {
 		Model:   h.agent.GetModelName(),
 		Message: "模型切换成功",
 	})
+}
+
+func isInvalidModelError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	indicators := []string{
+		"failed to parse model",
+		"invalid model format",
+		"unknown provider",
+		"provider not configured",
+		"model not found",
+	}
+	for _, s := range indicators {
+		if strings.Contains(msg, s) {
+			return true
+		}
+	}
+	return false
 }

--- a/api/handlers/config_test.go
+++ b/api/handlers/config_test.go
@@ -1,0 +1,92 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"k8s-wizard/api/models"
+
+	"github.com/gin-gonic/gin"
+)
+
+type mockConfigAgent struct {
+	setModelErr error
+}
+
+func (m *mockConfigAgent) ProcessCommandWithClarification(ctx context.Context, userMsg string, formData map[string]interface{}, confirm *bool) (string, *models.ClarificationRequest, *models.ActionPreview, error) {
+	return "", nil, nil, nil
+}
+
+func (m *mockConfigAgent) ProcessCommand(ctx context.Context, userMsg string) (string, error) {
+	return "", nil
+}
+
+func (m *mockConfigAgent) GetModelName() string {
+	return "mock-model"
+}
+
+func (m *mockConfigAgent) SetModel(modelString string) error {
+	return m.setModelErr
+}
+
+func TestConfigHandler_SetModel_InvalidModelReturnsBadRequest(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	handler := NewConfigHandler(&mockConfigAgent{
+		setModelErr: errors.New("failed to parse model: invalid model format: invalid-model"),
+	})
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	req := httptest.NewRequest(http.MethodPut, "/api/config/model", strings.NewReader(`{"model":"invalid-model","persist":false}`))
+	req.Header.Set("Content-Type", "application/json")
+	c.Request = req
+
+	handler.SetModel(c)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+	var resp models.SetModelResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if resp.Success {
+		t.Fatal("expected success=false")
+	}
+	if !strings.Contains(resp.Error, "模型切换失败") {
+		t.Fatalf("unexpected error response: %s", resp.Error)
+	}
+}
+
+func TestConfigHandler_SetModel_InternalErrorReturnsInternalServerError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	handler := NewConfigHandler(&mockConfigAgent{
+		setModelErr: errors.New("failed to create LLM client: API key not configured"),
+	})
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	req := httptest.NewRequest(http.MethodPut, "/api/config/model", strings.NewReader(`{"model":"glm/glm-4-flash","persist":false}`))
+	req.Header.Set("Content-Type", "application/json")
+	c.Request = req
+
+	handler.SetModel(c)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusInternalServerError)
+	}
+	var resp models.SetModelResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if resp.Success {
+		t.Fatal("expected success=false")
+	}
+}

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -312,6 +313,16 @@ func (c *KubernetesClient) GetPodLogs(ctx context.Context, namespace string, pod
 
 var dangerousShellPattern = regexp.MustCompile(`[;&|` + "`" + `$<>]|\$\(|\r|\n`)
 
+var shellInterpreters = map[string]struct{}{
+	"sh":   {},
+	"bash": {},
+	"zsh":  {},
+	"dash": {},
+	"ksh":  {},
+	"ash":  {},
+	"fish": {},
+}
+
 // ExecPod executes a command in a pod.
 func (c *KubernetesClient) ExecPod(ctx context.Context, namespace string, pod string, container string, command []string) (string, error) {
 	// Validate parameters
@@ -335,7 +346,8 @@ func (c *KubernetesClient) ExecPod(ctx context.Context, namespace string, pod st
 			return "", fmt.Errorf("command argument at index %d contains null byte", i)
 		}
 	}
-	if isShellCommand(command) && dangerousShellPattern.MatchString(command[2]) {
+	if shellCmd, cmdIdx := isShellCommand(command); shellCmd && cmdIdx >= 0 &&
+		dangerousShellPattern.MatchString(command[cmdIdx]) {
 		return "", fmt.Errorf("unsafe shell command rejected")
 	}
 
@@ -381,15 +393,41 @@ func (c *KubernetesClient) ExecPod(ctx context.Context, namespace string, pod st
 	return buf.String(), nil
 }
 
-func isShellCommand(command []string) bool {
+func isShellCommand(command []string) (bool, int) {
 	if len(command) < 3 {
-		return false
+		return false, -1
 	}
 
-	switch command[0] {
-	case "sh", "bash", "zsh", "dash", "ksh", "ash":
-		return command[1] == "-c"
-	default:
-		return false
+	shellName := strings.TrimPrefix(filepath.Base(strings.TrimSpace(command[0])), "-")
+	if _, ok := shellInterpreters[shellName]; !ok {
+		return false, -1
 	}
+
+	for i := 1; i < len(command); i++ {
+		arg := command[i]
+		if arg == "--" {
+			break
+		}
+		if !strings.HasPrefix(arg, "-") || arg == "-" {
+			break
+		}
+
+		// Direct -c form: sh -c "cmd"
+		if arg == "-c" {
+			if i+1 < len(command) {
+				return true, i + 1
+			}
+			return false, -1
+		}
+
+		// Combined short options: -lc / -ec / -cl
+		if !strings.HasPrefix(arg, "--") && strings.Contains(arg[1:], "c") {
+			if i+1 < len(command) {
+				return true, i + 1
+			}
+			return false, -1
+		}
+	}
+
+	return false, -1
 }

--- a/pkg/k8s/client_test.go
+++ b/pkg/k8s/client_test.go
@@ -559,6 +559,24 @@ func TestExecPod_ValidationErrors(t *testing.T) {
 			wantErr:   true,
 			errMsg:    "unsafe shell command rejected",
 		},
+		{
+			name:      "unsafe bash -lc command",
+			namespace: "test-ns",
+			pod:       "test-pod",
+			container: "test-container",
+			command:   []string{"bash", "-lc", "echo ok; rm -rf /"},
+			wantErr:   true,
+			errMsg:    "unsafe shell command rejected",
+		},
+		{
+			name:      "unsafe sh -ec command",
+			namespace: "test-ns",
+			pod:       "test-pod",
+			container: "test-container",
+			command:   []string{"sh", "-ec", "echo ok && id | cat"},
+			wantErr:   true,
+			errMsg:    "unsafe shell command rejected",
+		},
 	}
 
 	for _, tt := range tests {
@@ -570,6 +588,54 @@ func TestExecPod_ValidationErrors(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
+		})
+	}
+}
+
+func TestIsShellCommand(t *testing.T) {
+	tests := []struct {
+		name      string
+		command   []string
+		wantShell bool
+		wantIdx   int
+	}{
+		{
+			name:      "sh -c",
+			command:   []string{"sh", "-c", "echo ok"},
+			wantShell: true,
+			wantIdx:   2,
+		},
+		{
+			name:      "bash -lc",
+			command:   []string{"bash", "-lc", "echo ok"},
+			wantShell: true,
+			wantIdx:   2,
+		},
+		{
+			name:      "sh -ec",
+			command:   []string{"sh", "-ec", "echo ok"},
+			wantShell: true,
+			wantIdx:   2,
+		},
+		{
+			name:      "absolute shell path",
+			command:   []string{"/bin/bash", "-lc", "echo ok"},
+			wantShell: true,
+			wantIdx:   2,
+		},
+		{
+			name:      "non shell command",
+			command:   []string{"echo", "ok"},
+			wantShell: false,
+			wantIdx:   -1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotShell, gotIdx := isShellCommand(tt.command)
+			assert.Equal(t, tt.wantShell, gotShell)
+			assert.Equal(t, tt.wantIdx, gotIdx)
 		})
 	}
 }

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -7,11 +7,37 @@ import type {
 
 const API_BASE = (import.meta as any).env?.VITE_API_URL || '/api';
 
+const ENV_API_TOKEN =
+  (import.meta as any).env?.VITE_API_TOKEN ||
+  (import.meta as any).env?.VITE_AUTH_TOKEN ||
+  '';
+
+function resolveAuthToken(): string {
+  const runtimeToken =
+    (globalThis as any).__K8S_WIZARD_API_TOKEN__ ||
+    (globalThis as any).__APP_CONFIG__?.apiToken ||
+    '';
+  return runtimeToken || ENV_API_TOKEN;
+}
+
+function withAuthHeaders(headers: HeadersInit = {}): HeadersInit {
+  const merged = new Headers(headers);
+  if (!merged.has('Authorization')) {
+    const token = resolveAuthToken();
+    if (token) {
+      merged.set('Authorization', token.startsWith('Bearer ') ? token : `Bearer ${token}`);
+    }
+  }
+  return merged;
+}
+
 export const api = {
   // 健康检查
   async checkHealth(): Promise<boolean> {
     try {
-      const response = await fetch(`${API_BASE.replace('/api', '')}/health`);
+      const response = await fetch(`${API_BASE.replace('/api', '')}/health`, {
+        headers: withAuthHeaders(),
+      });
       const data = await response.json();
       return data.status === 'ok';
     } catch (error) {
@@ -26,9 +52,7 @@ export const api = {
 
     const response = await fetch(`${API_BASE}/chat`, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
+      headers: withAuthHeaders({ 'Content-Type': 'application/json' }),
       body: JSON.stringify(request),
     });
 
@@ -48,9 +72,7 @@ export const api = {
   async sendChat(request: ChatRequest): Promise<ChatResponse> {
     const response = await fetch(`${API_BASE}/chat`, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
+      headers: withAuthHeaders({ 'Content-Type': 'application/json' }),
       body: JSON.stringify(request),
     });
 
@@ -68,7 +90,9 @@ export const api = {
       type,
       namespace,
     });
-    const response = await fetch(`${API_BASE}/resources?${params.toString()}`);
+    const response = await fetch(`${API_BASE}/resources?${params.toString()}`, {
+      headers: withAuthHeaders(),
+    });
 
     if (!response.ok) {
       const errorData = (await response.json()) as ChatResponse;
@@ -81,7 +105,9 @@ export const api = {
 
   // 获取模型信息
   async getModelInfo(): Promise<ModelInfoResponse> {
-    const response = await fetch(`${API_BASE}/config/model`);
+    const response = await fetch(`${API_BASE}/config/model`, {
+      headers: withAuthHeaders(),
+    });
 
     if (!response.ok) {
       throw new Error(`HTTP ${response.status}: Failed to get model info`);
@@ -92,7 +118,9 @@ export const api = {
 
   // 获取完整配置
   async getConfig(): Promise<ConfigResponse> {
-    const response = await fetch(`${API_BASE}/config`);
+    const response = await fetch(`${API_BASE}/config`, {
+      headers: withAuthHeaders(),
+    });
 
     if (!response.ok) {
       throw new Error(`HTTP ${response.status}: Failed to get config`);
@@ -105,9 +133,7 @@ export const api = {
   async setModel(model: string): Promise<{ success: boolean; model: string; message?: string }> {
     const response = await fetch(`${API_BASE}/config/model`, {
       method: 'PUT',
-      headers: {
-        'Content-Type': 'application/json',
-      },
+      headers: withAuthHeaders({ 'Content-Type': 'application/json' }),
       body: JSON.stringify({ model }),
     });
 


### PR DESCRIPTION
## Summary
- Improve ExecPod shell injection detection to cover bash -lc, sh -ec variants
- Add Authorization header support to frontend API client
- Return 400 for invalid model in SetModel (was 500)

## Changes
- `pkg/k8s/client.go`:
  - Added `shellInterpreters` map for common shells (sh/bash/zsh/dash/ksh/ash/fish)
  - Enhanced `isShellCommand()` to detect -lc, -ec, -cl options
  - Returns shell command index for proper dangerous arg detection
- `pkg/k8s/client_test.go`:
  - Added tests for bash -lc, sh -ec command variants
  - Added TestIsShellCommand to verify shell detection logic
- `web/src/services/api.ts`:
  - Added `resolveAuthToken()` function to get token from env/runtime
  - Added `withAuthHeaders()` helper to inject Authorization header
  - Applied to all API calls (checkHealth, sendMessage, sendChat, getResources, getModelInfo, getConfig, setModel)
- `api/handlers/config.go`:
  - Added `isInvalidModelError()` helper to distinguish 4xx vs 5xx
  - Updated SetModel to return 400 for invalid model errors
- `api/handlers/config_test.go` (new file):
  - Added TestConfigHandler_SetModel_InvalidModelReturnsBadRequest
  - Added TestConfigHandler_SetModel_InternalErrorReturnsInternalServerError

## Test Results
```
=== RUN   TestIsShellCommand
--- PASS: TestIsShellCommand (0.00s)
=== RUN   TestConfigHandler_SetModel_InvalidModelReturnsBadRequest
--- PASS: TestConfigHandler_SetModel_InvalidModelReturnsBadRequest (0.00s)
=== RUN   TestConfigHandler_SetModel_InternalErrorReturnsInternalServerError
--- PASS: TestConfigHandler_SetModel_InternalErrorReturnsInternalServerError (0.00s)
```

All tests passing:
- `go test ./api/handlers/...` ✓
- `go test ./pkg/k8s/...` ✓
- `npm run build` in web/ ✓

## Security Impact
Previously:
- ExecPod only blocked `<shell> -c <cmd>` form, missing bash -lc, sh -ec variants
- Frontend did not send Authorization token
- SetModel returned 500 for all errors (including invalid input)

Now:
- Shell detection covers common shells and -c/-lc/-ec/-cl option variants
- Frontend automatically includes Authorization header when token is configured
- SetModel correctly returns 400 for invalid models, 500 for internal errors

Addresses medium-risk issues from code review.